### PR TITLE
Interpret datetimes as UTC time (unless otherwise specified)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "camelcase-keys": "^7.0.0",
+        "dayjs": "^1.10.7",
         "isomorphic-fetch": "^3.0.0"
       },
       "devDependencies": {
@@ -3408,6 +3409,11 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.10.7",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.7.tgz",
+      "integrity": "sha512-P6twpd70BcPK34K26uJ1KT3wlhpuOAPoMwJzpsIWUxHZ7wpmbdZL/hQqBDfz7hGurYSa5PhzdhDHtt319hL3ig=="
     },
     "node_modules/debug": {
       "version": "4.3.2",
@@ -10722,6 +10728,11 @@
         "whatwg-mimetype": "^2.3.0",
         "whatwg-url": "^8.0.0"
       }
+    },
+    "dayjs": {
+      "version": "1.10.7",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.7.tgz",
+      "integrity": "sha512-P6twpd70BcPK34K26uJ1KT3wlhpuOAPoMwJzpsIWUxHZ7wpmbdZL/hQqBDfz7hGurYSa5PhzdhDHtt319hL3ig=="
     },
     "debug": {
       "version": "4.3.2",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
   },
   "dependencies": {
     "camelcase-keys": "^7.0.0",
+    "dayjs": "^1.10.7",
     "isomorphic-fetch": "^3.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "octane-node",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "Node bindings for the Octane API",
   "author": "team@getoctane.io",
   "main": "index.js",

--- a/src/resources/customers.ts
+++ b/src/resources/customers.ts
@@ -1,3 +1,5 @@
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
 import {
   CreateCustomerArgs,
   CreateSubscriptionArgs,
@@ -12,9 +14,11 @@ import {
   UpdateCustomerArgs,
   UpdateSubscriptionArgs,
 } from '../codegen/api';
-import { ClientConfiguration } from '../types';
 import { Configuration as APIConfiguration } from '../codegen/configuration';
+import { ClientConfiguration } from '../types';
 import { BaseResource } from './base';
+
+dayjs.extend(utc);
 
 class Customers extends BaseResource {
   private api: CustomersApi;
@@ -158,11 +162,14 @@ class Customers extends BaseResource {
     let startTimeAsDate: Date | undefined;
     if (startTime) {
       startTimeAsDate =
-        startTime instanceof Date ? startTime : new Date(startTime);
+        startTime instanceof Date
+          ? startTime
+          : dayjs(startTime).utc(true).toDate();
     }
     let endTimeAsDate: Date | undefined;
     if (endTime) {
-      endTimeAsDate = endTime instanceof Date ? endTime : new Date(endTime);
+      endTimeAsDate =
+        endTime instanceof Date ? endTime : dayjs(endTime).utc(true).toDate();
     }
     return this.api
       .customersCustomerNameUsageGet(

--- a/src/resources/measurements.ts
+++ b/src/resources/measurements.ts
@@ -1,7 +1,11 @@
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
 import { Measurement, MeasurementsApi } from '../codegen/api';
 import { Configuration as APIConfiguration } from '../codegen/configuration';
 import { ClientConfiguration } from '../types';
 import { BaseResource } from './base';
+
+dayjs.extend(utc);
 
 interface MeasurementInput extends Omit<Measurement, 'time'> {
   time?: Date | string;
@@ -41,7 +45,7 @@ function normalizeMeasurementInput({
 }: MeasurementInput | Measurement): Measurement {
   let timestamp: Date | undefined;
   if (time) {
-    timestamp = time instanceof Date ? time : new Date(time);
+    timestamp = time instanceof Date ? time : dayjs(time).utc(true).toDate();
   }
   return {
     time: timestamp,


### PR DESCRIPTION
Prior to this change, we were assuming all date & time inputs to be present (local) time (and then converting to UTC).
By adding dayjs lib here we can read in the date string and convert to UTC accordingly before converting to JS Date.