### PR TITLE
[hotfix] re-fix reference path for custom.d.ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "octane-node",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "Node bindings for the Octane API",
   "author": "team@getoctane.io",
   "main": "index.js",

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -11,7 +11,7 @@ tsc -p tsconfig.json
 
 # Fix for bug in v0.5.0
 cp src/codegen/custom.d.ts build/codegen/
-cat build/codegen/api.d.ts | sed 's/\.\.\/\.\.\/src\/codegen\/custom\.d\.ts/\.\/custom\.d\.ts/g' \
+cat build/codegen/api.d.ts | sed 's/codegen\/custom/\.\/custom/g' \
   > build/codegen/api.d.ts.tmp
 mv build/codegen/api.d.ts.tmp build/codegen/api.d.ts
 

--- a/src/resources/__tests__/__snapshots__/measurements.test.ts.snap
+++ b/src/resources/__tests__/__snapshots__/measurements.test.ts.snap
@@ -5,7 +5,7 @@ Array [
   Array [
     "https://api.made.up.host:1337/measurements/",
     Object {
-      "body": "{\\"meter_name\\":\\"someMeter\\",\\"time\\":\\"2021-09-10T16:36:59.663Z\\",\\"value\\":9001}",
+      "body": "{\\"meter_name\\":\\"someMeter\\",\\"time\\":\\"2021-09-10T12:36:59.663Z\\",\\"value\\":9001}",
       "headers": Object {
         "Authorization": "Bearer 867-5309",
         "Content-Type": "application/json",
@@ -16,7 +16,7 @@ Array [
   Array [
     "https://api.made.up.host:1337/measurements/",
     Object {
-      "body": "{\\"meter_name\\":\\"someMeter\\",\\"time\\":\\"2021-09-10T16:36:59.663Z\\",\\"value\\":9001}",
+      "body": "{\\"meter_name\\":\\"someMeter\\",\\"time\\":\\"2021-09-10T12:36:59.663Z\\",\\"value\\":9001}",
       "headers": Object {
         "Authorization": "Bearer 867-5309",
         "Content-Type": "application/json",

--- a/src/resources/__tests__/measurements.test.ts
+++ b/src/resources/__tests__/measurements.test.ts
@@ -1,6 +1,10 @@
-import { Measurements } from 'resources/measurements';
-import fetchMock from 'jest-fetch-mock';
 import type { Measurement } from 'codegen/api';
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+import fetchMock from 'jest-fetch-mock';
+import { Measurements } from 'resources/measurements';
+
+dayjs.extend(utc);
 
 const API_CONFIG = {
   apiKey: '867-5309',
@@ -31,7 +35,7 @@ describe('Measurements resource', () => {
     fetchMock.once(JSON.stringify(FAKE_MEASUREMENT));
     const resp2 = await m.create({
       ...FAKE_MEASUREMENT,
-      time: new Date(FAKE_ISO_STRING),
+      time: dayjs(FAKE_ISO_STRING).utc(true).toDate(),
     });
     expect(resp2).toEqual(FAKE_MEASUREMENT);
     const secondRequest = fetchMock.mock.calls[1];


### PR DESCRIPTION
it's unclear what change affected this, but the TS reference path types changed and the codegen was out of sync with it, causing some TS errors on build.

AI: We should add these problematic build steps into the automation checks to prevent this from recurring

Test plan:
- Linked a local version of the `octane-node` repo to an app that was consuming it (using `npm link`)
- Run `npm run-script build`

Before:
Encounter error as reported

After:
No errors, build successfully finished.