### PR TITLE
Add acceptance test for typescript app

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -1,6 +1,6 @@
-name: build
+name: build-pr
 on:
-  push:
+  pull_request:
     branches:
       - main
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Build octane-node
         run: |
           npm install
-          npm run-script build
+          npm run-script test
       - name: Release package to npmjs
         run: |
           echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > "${HOME}/.npmrc"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "octane-node",
-  "version": "0.7.2",
+  "version": "0.7.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "octane-node",
-      "version": "0.7.2",
+      "version": "0.7.4",
       "license": "MIT",
       "dependencies": {
         "camelcase-keys": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -13,14 +13,15 @@
   "scripts": {
     "codegen": "scripts/codegen.sh",
     "build": "scripts/build.sh",
+    "acceptance": "scripts/acceptance.sh",
     "publish": "scripts/publish.sh",
     "fix": "run-s fix:*",
     "fix:prettier": "prettier \"src/**/*.ts\" --write",
     "fix:lint": "eslint src --ext .ts --fix",
-    "jest": "jest",
+    "jest": "TZ=America/New_York jest",
     "update-jest-snapshots": "jest -u",
-    "test": "run-s build test:*",
-    "test:jest": "jest",
+    "test": "run-s build test:* acceptance",
+    "test:jest": "TZ=America/New_York jest",
     "test:lint": "eslint src --ext .ts",
     "test:prettier": "prettier \"src/**/*.ts\" --list-different"
   },

--- a/scripts/acceptance.sh
+++ b/scripts/acceptance.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -ex
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd $DIR/../
+
+cd testdata/simple-typescript-app/
+npm install
+
+# Manually copy the "octane-node" dependency from our built version
+rm -rf node_modules/octane-node/
+mkdir node_modules/octane-node/
+cp -r ../../build/* node_modules/octane-node/
+
+# See if we can build
+npm run-script build
+
+# See if we can run
+npm start

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -11,7 +11,7 @@ tsc -p tsconfig.json
 
 # Fix for bug in v0.5.0
 cp src/codegen/custom.d.ts build/codegen/
-cat build/codegen/api.d.ts | sed 's/\.\.\/\.\.\/src\/codegen\/custom\.d\.ts/\.\/custom\.d\.ts/g' \
+cat build/codegen/api.d.ts | sed 's/codegen\/custom/\.\/custom/g' \
   > build/codegen/api.d.ts.tmp
 mv build/codegen/api.d.ts.tmp build/codegen/api.d.ts
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -11,7 +11,7 @@ tsc -p tsconfig.json
 
 # Fix for bug in v0.5.0
 cp src/codegen/custom.d.ts build/codegen/
-cat build/codegen/api.d.ts | sed 's/codegen\/custom/\.\/custom/g' \
+cat build/codegen/api.d.ts | sed 's/\.\.\/\.\.\/src\/codegen\/custom\.d\.ts/\.\/custom\.d\.ts/g' \
   > build/codegen/api.d.ts.tmp
 mv build/codegen/api.d.ts.tmp build/codegen/api.d.ts
 

--- a/testdata/simple-typescript-app/.gitignore
+++ b/testdata/simple-typescript-app/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/testdata/simple-typescript-app/package-lock.json
+++ b/testdata/simple-typescript-app/package-lock.json
@@ -1,0 +1,34 @@
+{
+  "name": "simple-typescript-app",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "simple-typescript-app",
+      "version": "1.0.0",
+      "dependencies": {
+        "typescript": "^4.4.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
+      "integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    }
+  },
+  "dependencies": {
+    "typescript": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
+      "integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA=="
+    }
+  }
+}

--- a/testdata/simple-typescript-app/package.json
+++ b/testdata/simple-typescript-app/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "simple-typescript-app",
+  "version": "1.0.0",
+  "description": "Simple typescript app to see if we can include built version of octane-node",
+  "scripts": {
+    "build": "rm -rf dist && tsc",
+    "start": "node dist/index.js"
+  },
+  "dependencies": {
+    "typescript": "^4.4.3"
+  }
+}

--- a/testdata/simple-typescript-app/src/index.ts
+++ b/testdata/simple-typescript-app/src/index.ts
@@ -1,0 +1,5 @@
+import util from 'util';
+import Octane from 'octane-node';
+
+const octane = new Octane('abc123');
+console.log(util.inspect(octane, {depth: 0}));

--- a/testdata/simple-typescript-app/tsconfig.json
+++ b/testdata/simple-typescript-app/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "es5",                                     /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    "module": "commonjs",                                /* Specify what module code is generated. */
+    "outDir": "dist",                                   /* Specify an output folder for all emitted files. */
+    "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables `allowSyntheticDefaultImports` for type compatibility. */
+    "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
+    "strict": true,                                      /* Enable all strict type-checking options. */                             /* Skip type checking all .d.ts files. */
+  }
+}


### PR DESCRIPTION
Add a simple test app to see that the built version of the package can be imported in another app successfully.

Removed `build` step in CI (`test` runs `build`).

Also, added timezone for Jest tests (which fail if run in timezone other than EST).