### PR TITLE
Don't ignore /build when publishing

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+# This file is blank intentionally — if it isn't here, NPM uses .gitignore when deciding
+# what to publish, and .gitignore ignores our build folder.

--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
   "name": "octane-node",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "description": "Node bindings for the Octane API",
   "author": "team@getoctane.io",
-  "main": "index.js",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "repository": "https://github.com/getoctane/octane-node",
   "license": "MIT",
   "keywords": [

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -8,16 +8,3 @@ cd $DIR/../
 rm -rf build/
 trap "rm -f ${PWD}/tsconfig.tsbuildinfo" EXIT
 tsc -p tsconfig.json
-
-# Remove test files
-rm -rf build/resources/__tests__/
-
-cp LICENSE build/
-cp README.md build/
-
-# Remove dev-related fields from package.json
-node -e "
-let j=JSON.parse(require('fs').readFileSync('./package.json'))
-delete j['scripts']
-delete j['devDependencies']
-console.log(JSON.stringify(j,null,2))" > build/package.json


### PR DESCRIPTION
We used to publish /build directly, but that's not super conventional —  it means having to put package.json, license files, etc. in the build folder.

It's a lot more common to just publish the whole package and specify the index file, inside the build folder, in package.json. To do that we'll need a separate npmignore to ensure that out build folder actually gets published.  NPM uses .gitignore by default, which ignores our build folder.